### PR TITLE
Update the backend processing of opening hours feed to a new structure

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -53,6 +53,11 @@ parameters:
     koba_apikey: 1234
     koba_path:   http://192.168.50.21
 
+    # Base URL for the DDB CMS installation.
     ding_url: 'http://bibliotek.kk.dk'
-    ding_opening_hours_library_open_keys: 'åben,åbent'
-    ding_opening_hours_library_service_keys: 'biblioteksbetjening'
+
+    # Drupal taxonomy term id's for Opening Hours interval categories.
+    ding_opening_hours_category:
+      libraryservice: 14291
+      citizenservices: 14292
+

--- a/src/Kkb/Ding2IntegrationBundle/README.md
+++ b/src/Kkb/Ding2IntegrationBundle/README.md
@@ -2,10 +2,16 @@
 
 
 ## Setup
-Add the following parameters to parameters.yml to enable integration and configure how to identify opening hours and service-intervals.:
+Add the following parameters to parameters.yml to enable integration and 
+configure how to identify opening hours and service-intervals.:
 
 <pre>
       ding_url: 'http://bibliotek.kk.dk'
-      ding_opening_hours_library_open_keys: 'åben,åbent'
-      ding_opening_hours_library_service_keys: 'biblioteksbetjening'
+      ding_opening_hours_category:
+        libraryservice: 14291
+        citizenservices: 14292  
 </pre>
+
+The values for the `libraryservice` and `citizenservices` keys are Drupal term
+identifies for Opening Hours taxonomy terms. Consult an administrator for the 
+DDB CMS installation to get the ids.  

--- a/web/templates/ding2/slides/opening-hours/opening-hours-edit.html
+++ b/web/templates/ding2/slides/opening-hours/opening-hours-edit.html
@@ -15,7 +15,7 @@
       <div class="opening-hours--content">
 
         <div class="opening-hours--description"
-             ng-if="!ikSlide.options.feed.library && !ikSlide.options.feed.citizenservices"
+             ng-if="!ikSlide.options.feed.library"
              data-ng-style="{'color': ikSlide.options.textcolor}">(Angiv et biblioteks-id for at vise en tekst her)</div>
 
         <div class="opening-hours--description"
@@ -27,7 +27,7 @@
              data-ng-style="{'color': ikSlide.options.textcolor}">og der er betjening kl 13-15</div>
 
         <div class="opening-hours--description opening-hours--description__seperated"
-             ng-if="ikSlide.options.feed.citizenservices"
+             ng-if="ikSlide.options.feed.citizenservicesenabled"
              data-ng-style="{'color': ikSlide.options.textcolor}">Borgerservice åbent i dag 8-17</div>
 
       </div>

--- a/web/templates/ding2/slides/opening-hours/opening-hours-live.html
+++ b/web/templates/ding2/slides/opening-hours/opening-hours-live.html
@@ -12,16 +12,16 @@
       <div class="opening-hours--content">
 
         <div class="opening-hours--description"
-             ng-if="ikSlide.intervalTexts.library.open"
-             data-ng-style="{'color': ikSlide.options.textcolor}">{{ikSlide.intervalTexts.library.open}}</div>
+             ng-if="ikSlide.intervalTexts.general"
+             data-ng-style="{'color': ikSlide.options.textcolor}">{{ikSlide.intervalTexts.general}}</div>
 
         <div class="opening-hours--description opening-hours--description__sub"
-             ng-if="ikSlide.intervalTexts.library.service"
-             data-ng-style="{'color': ikSlide.options.textcolor}">{{ikSlide.intervalTexts.library.service}}</div>
+             ng-if="ikSlide.intervalTexts.general && ikSlide.intervalTexts.libraryservice"
+             data-ng-style="{'color': ikSlide.options.textcolor}">{{ikSlide.intervalTexts.libraryservice}}</div>
 
         <div class="opening-hours--description  opening-hours--description__seperated"
-             ng-if="ikSlide.intervalTexts.citizenservices.open"
-             data-ng-style="{'color': ikSlide.options.textcolor}">{{ikSlide.intervalTexts.citizenservices.open}}</div>
+             ng-if="ikSlide.intervalTexts.citizenservices"
+             data-ng-style="{'color': ikSlide.options.textcolor}">{{ikSlide.intervalTexts.citizenservices}}</div>
       </div>
       <div class="opening-hours--footer-wrapper" data-ng-style="{'background-color': ikSlide.options.bgcolor, 'color': ikSlide.options.textcolor}">
         <div class="opening-hours--footer">{{ikSlide.options.footertext}}</div>

--- a/web/templates/ding2/slides/opening-hours/opening-hours-preview.html
+++ b/web/templates/ding2/slides/opening-hours/opening-hours-preview.html
@@ -2,7 +2,7 @@
   <div class="opening-hours--text-wrapper">
     <div class="opening-hours--text-inner">
       <div class="opening-hours--date"
-           data-ng-style="{'color': ikSlide.options.textcolor}">{{ikSlide.date_headline}}</div>
+           data-ng-style="{'color': ikSlide.options.textcolor}">Mandag d. 19. marts 2018</div>
 
       <div class="opening-hours--header-wrapper" data-ng-style="{'background-color': ikSlide.options.bgcolor, 'color': ikSlide.options.textcolor}">
         <div class="opening-hours--header">{{ikSlide.options.headertext}}</div>
@@ -19,7 +19,7 @@
              data-ng-style="{'color': ikSlide.options.textcolor}">og der er betjening kl 13-15</div>
 
         <div class="opening-hours--description opening-hours--description__seperated"
-             ng-if="ikSlide.options.feed.citizenservices"
+             ng-if="ikSlide.options.feed.citizenservicesenabled"
              data-ng-style="{'color': ikSlide.options.textcolor}">Borgerservice åbent i dag 8-17</div>
 
       </div>

--- a/web/templates/editors/opening-hours-editor.html
+++ b/web/templates/editors/opening-hours-editor.html
@@ -17,8 +17,8 @@
           <input type="text" data-ng-model="ikSlide.options.feed.library">
         </div>
         <div class="edit-menu--iframe-content">
-          <div class="edit-menu--iframe-label">Borgerservice ID på bibliotek.kk.dk (valgfrit)</div>
-          <input type="text" data-ng-model="ikSlide.options.feed.citizenservices">
+          <div class="edit-menu--iframe-label">Vis borgerservice åbningstid (hvis til stede i feedet)?</div>
+          <input type="checkbox" data-ng-model="ikSlide.options.feed.citizenservicesenabled">
         </div>
       </div>
     </div>

--- a/web/templates/js/openingHoursSlide.js
+++ b/web/templates/js/openingHoursSlide.js
@@ -44,10 +44,6 @@ if (!window.slideFunctions['opening-hours']) {
             if (slide.options.feed.library) {
                 region.itkLog.info("- library nid: " + slide.options.feed.library);
             }
-
-            if (slide.options.feed.citizenservices) {
-                region.itkLog.info("- citizen services nid: " + slide.options.feed.citizenservices);
-            }
         }
 
         // Get the strings we're going to display on the slide.


### PR DESCRIPTION
The feed has changed from consisting of two seperate feeds for citizenservices
and general library services, to a single combined feed with categorized
intervals.

The upgraded integration now uses these categories instead of relying on legacy
"notice" fields which also aliviates us from having configurations for
detecting these text-strings.

Instead we now use categories controlled via Drupal terms.

The mixing of intervals into the same feed also means we now need the admin to
explicitly tell us whether to expect citizenservices intervals in the feed. To
handle this the previous text-input field in the backend that held the id of the
citizenservices node has now been changed to a checkbox.

OS-70